### PR TITLE
Arregla (la mayoria) de los casos de prueba

### DIFF
--- a/curp.js
+++ b/curp.js
@@ -175,6 +175,23 @@
     return curp_str + digito;
   }
 
+  /**
+   * extraerInicial()
+   * Funcion que extrae la inicial del primer nombre, o, si tiene mas de 1 nombre Y el primer
+   * nombre es uno de la lista de nombres comunes, la inicial del segundo nombre
+   * @param {string} nombre - String que representa todos los nombres (excepto los apellidos) separados por espacio
+   */
+  function extrarInicial(nombre) {
+    var nombres, primerNombreEsComun;
+    nombres = nombre.toUpperCase().trim().split(/\s+/);
+    primerNombreEsComun = (nombres.length > 1 && comunes.indexOf(nombres[0]) > -1);
+
+    if (primerNombreEsComun) {
+      return nombres[1].substring(0, 1);
+    }
+
+    return nombres[0].substring(0, 1);
+  }
 
   /**
   * generaCurp()
@@ -192,7 +209,7 @@
   * Por default es 0 si la fecha de nacimiento es menor o igual a 1999, o A, si es igual o mayor a 2000.
   */
   function generaCurp(param) {
-    var inicial_nombre, vocal_apellido, posicion_1_4, posicion_14_16, curp, primera_letra_paterno, primera_letra_materno;
+    var inicial_nombre, vocal_apellido, posicion_1_4, posicion_14_16, curp, primera_letra_paterno, primera_letra_materno, nombres, nombre_a_usar;
 
     if (!estadoValido(param.estado)) {
       return false;
@@ -210,18 +227,10 @@
       nombres = nombre.toUpperCase().trim().split(/\s+/);
       primerNombreEsComun = (nombres.length > 1 && comunes.indexOf(nombres[0]) > -1);
 
-      if (primerNombreEsComun) {
-        return nombres[1].substring(0, 1);
-      }
-      if (!primerNombreEsComun) {
-        return nombres[0].substring(0, 1);
-      }
-    }(param.nombre));
+    inicial_nombre = extrarInicial(param.nombre);
 
     vocal_apellido = param.apellido_paterno.trim().substring(1).replace(/[^AEIOU]/g, '').substring(0, 1);
     vocal_apellido = (vocal_apellido === '') ? 'X' : vocal_apellido;
-
-
 
     primera_letra_paterno = param.apellido_paterno.substring(0, 1);
     primera_letra_paterno = primera_letra_paterno === 'Ñ' ? 'X' : primera_letra_paterno;
@@ -237,10 +246,15 @@
 
     posicion_1_4 = filtraInconvenientes(filtraCaracteres(posicion_1_4));
 
+    nombres = param.nombre.split(" ").filter(function (palabra) {
+      return palabra !== "";
+    });
+    nombre_a_usar = comunes.indexOf(nombres[0]) > -1 ? nombres[1] : nombres[0];
+
     posicion_14_16 = [
       primerConsonante(param.apellido_paterno),
       primerConsonante(param.apellido_materno),
-      primerConsonante(param.nombre)
+      primerConsonante(nombre_a_usar)
     ].join('');
 
     curp = [

--- a/curp.js
+++ b/curp.js
@@ -125,11 +125,11 @@
     origen  = [ 'Ã', 'À', 'Á', 'Ä', 'Â', 'È', 'É', 'Ë', 'Ê', 'Ì', 'Í', 'Ï', 'Î',
              'Ò', 'Ó', 'Ö', 'Ô', 'Ù', 'Ú', 'Ü', 'Û', 'ã', 'à', 'á', 'ä', 'â',
              'è', 'é', 'ë', 'ê', 'ì', 'í', 'ï', 'î', 'ò', 'ó', 'ö', 'ô', 'ù',
-             'ú', 'ü', 'û', 'Ñ', 'ñ', 'Ç', 'ç' ];
+             'ú', 'ü', 'û', 'Ç', 'ç' ];
     destino = [ 'A', 'A', 'A', 'A', 'A', 'E', 'E', 'E', 'E', 'I', 'I', 'I', 'I',
              'O', 'O', 'O', 'O', 'U', 'U', 'U', 'U', 'a', 'a', 'a', 'a', 'a',
              'e', 'e', 'e', 'e', 'i', 'i', 'i', 'i', 'o', 'o', 'o', 'o', 'u',
-             'u', 'u', 'u', 'n', 'n', 'c', 'c' ];
+             'u', 'u', 'u', 'c', 'c' ];
     str     = str.split('');
     salida  = str.map(function (char) {
       var pos = origen.indexOf(char);
@@ -192,7 +192,7 @@
   * Por default es 0 si la fecha de nacimiento es menor o igual a 1999, o A, si es igual o mayor a 2000.
   */
   function generaCurp(param) {
-    var inicial_nombre, vocal_apellido, posicion_1_4, posicion_14_16, curp;
+    var inicial_nombre, vocal_apellido, posicion_1_4, posicion_14_16, curp, primera_letra_paterno, primera_letra_materno;
 
     if (!estadoValido(param.estado)) {
       return false;
@@ -221,10 +221,17 @@
     vocal_apellido = param.apellido_paterno.trim().substring(1).replace(/[^AEIOU]/g, '').substring(0, 1);
     vocal_apellido = (vocal_apellido === '') ? 'X' : vocal_apellido;
 
+
+
+    primera_letra_paterno = param.apellido_paterno.substring(0, 1);
+    primera_letra_paterno = primera_letra_paterno === 'Ñ' ? 'X' : primera_letra_paterno;
+    primera_letra_materno = param.apellido_materno.substring(0, 1);
+    primera_letra_materno = primera_letra_materno === 'Ñ' ? 'X' : primera_letra_materno;
+
     posicion_1_4 = [
-      param.apellido_paterno.substring(0, 1),
+      primera_letra_paterno,
       vocal_apellido,
-      param.apellido_materno.substring(0, 1),
+      primera_letra_materno,
       inicial_nombre
     ].join('');
 

--- a/curp.js
+++ b/curp.js
@@ -89,7 +89,7 @@
   */
   function primerConsonante(str) {
     str = str.trim().substring(1).replace(/[AEIOU]/ig, '').substring(0, 1);
-    return (str === '') ? 'X' : str;
+    return (str === '' || str === 'Ñ') ? 'X' : str;
   }
 
   /**

--- a/curp.js
+++ b/curp.js
@@ -79,8 +79,7 @@
 
     return (pad + num).replace(new RegExp('^.*([0-9]{' + ancho + '})$'), '$1');
   }
-  var pad = zeropad.bind(null, 2);
-
+  var pad = zeropad.bind(null, 2), comunes = [ 'MARIA', 'MA', 'MA.', 'JOSE', 'J', 'J.' ];
   /**
   * primerConsonante()
   * Saca la primer consonante interna del string, y la devuelve.
@@ -217,15 +216,9 @@
 
     param.nombre = ajustaCompuesto(normalizaString(param.nombre.toUpperCase())).trim();
     param.apellido_paterno = ajustaCompuesto(normalizaString(param.apellido_paterno.toUpperCase())).trim();
-    param.apellido_materno = ajustaCompuesto(normalizaString(param.apellido_materno.toUpperCase())).trim();
 
-    // La inicial del primer nombre, o, si tiene mas de 1 nombre Y el primer
-    // nombre es uno de la lista de nombres comunes, la inicial del segundo nombre
-    inicial_nombre = (function (nombre) {
-      var comunes, nombres, primerNombreEsComun;
-      comunes = [ 'MARIA', 'MA', 'MA.', 'JOSE', 'J', 'J.' ];
-      nombres = nombre.toUpperCase().trim().split(/\s+/);
-      primerNombreEsComun = (nombres.length > 1 && comunes.indexOf(nombres[0]) > -1);
+    param.apellido_materno = param.apellido_materno || "";
+    param.apellido_materno = ajustaCompuesto(normalizaString(param.apellido_materno.toUpperCase())).trim();
 
     inicial_nombre = extrarInicial(param.nombre);
 
@@ -234,8 +227,13 @@
 
     primera_letra_paterno = param.apellido_paterno.substring(0, 1);
     primera_letra_paterno = primera_letra_paterno === 'Ñ' ? 'X' : primera_letra_paterno;
-    primera_letra_materno = param.apellido_materno.substring(0, 1);
-    primera_letra_materno = primera_letra_materno === 'Ñ' ? 'X' : primera_letra_materno;
+
+    if (!param.apellido_materno || param.apellido_materno === "") {
+      primera_letra_materno = 'X';
+    } else {
+      primera_letra_materno = param.apellido_materno.substring(0, 1);
+      primera_letra_materno = primera_letra_materno === 'Ñ' ? 'X' : primera_letra_materno;
+    }
 
     posicion_1_4 = [
       primera_letra_paterno,

--- a/test/test.js
+++ b/test/test.js
@@ -24,7 +24,6 @@ describe('Posiciones 1-4', function () {
   it('Deberia regresar "x" si la primer letra de algun de los nombres es Ñ', function () {
     persona.setName('alberto', 'ñando', 'rodriguez');
     var letras = curp(persona).substr(0, 4);
-    // persona.toString();
     assert.equal(letras, 'XARA');
   });
 
@@ -32,14 +31,12 @@ describe('Posiciones 1-4', function () {
     it('Para Maria', function () {
       persona.setName('maria luisa', 'perez', 'hernandez');
       var letras = curp(persona).substr(0, 4);
-      // persona.toString();
       assert.equal(letras, 'PEHL');
     });
 
     it('Para compuesto regular', function () {
       persona.setName('luis enrique', 'romero', 'palazuelos');
       var letras = curp(persona).substr(0, 4);
-      // persona.toString();
       assert.equal(letras, 'ROPL');
     });
   });
@@ -47,7 +44,6 @@ describe('Posiciones 1-4', function () {
   it('Deberia regresar "X" en caso que un caracter especial como "/" o "-" vaya a ser utilizado en la creacion de la clave', function () {
     persona.setName("juan jose", "d/amico", "alvarez");
     var letras = curp(persona).substr(0, 4);
-    // persona.toString();
     assert.equal(letras, 'DXAJ');
   });
 


### PR DESCRIPTION
Con esta serie de commits se reparan la mayoria de los casos de excepcion segun [el documento oficial](http://www.gobernacion.gob.mx/work/models/SEGOB/Resource/231/2/images/InstructivoParaLaCurp_v2008.pdf). Solo hay un caso de excepcion que no se como interpretar

_Si en los apellidos o en el nombre aparecieran caracteres especiales como diagonal (__/__), guion (__-__), o punto (__.__), se captura tal cual viene en el documento probatorio y la aplicacion asignara una 'X' en caso de que esa posicion intervenga para la conformacion de la clave_

> Ejemplo: JUAN JOSE D/AMICO ALVAREZ  **DXAJ**

Esto no se me hace que no concuerda con la regla para crear posiciones 1-4

_La letra inicial y *_la primera vocal interna del primer apellido*_, la letra
inicial del segundo apellido y la primera letra del nombre. En el
caso de las mujeres casadas, se deberan usar los apellidos de soltera_

> **la primera vocal interna del primer apellido**

Donde aqui claramente dice usar la primera vocal, pero en el ejemplo _JUAN JOSE D/AMICO ALVAREZ_  el caracter especial viene antes de la vocal.

Por eso por ahorita deje este caso, no resuleto a ver si tienen sugerencias o que simplemente lo comentemos por ahorita.
